### PR TITLE
Don't leave the package's root directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require("../lib");
+module.exports = require("./lib");


### PR DESCRIPTION
This `require()` call attempts to fetch the `lib/` folder from outside of this project's root directory.
